### PR TITLE
Supporting tokio-postgres 0.5.0-alpha.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,21 +20,21 @@ travis-ci = { repository = "paupino/rust-decimal", branch = "master" }
 [dependencies]
 byteorder = "1.3"
 float-cmp = "0.5.0"
-futures = { version = "0.1", optional = true }
 num = "0.2"
 serde = { version = "1.0", optional = true }
-tokio = { version = "0.1.21", optional = true }
-tokio-postgres = { version = "0.4.0-rc.2", optional = true }
+tokio-postgres = { version = "0.5.0-alpha.1", optional = true }
+bytes = { version = "0.4" }
 
 [dev-dependencies]
 rand = "0.6"
 serde_json = "1.0"
 serde_derive = "1.0"
+tokio = { version = "0.2.0-alpha.6" }
+futures-preview = { version = "0.3.0-alpha.19" }
 
 [features]
 default = ["serde"]
-
-postgres = ["futures", "tokio", "tokio-postgres"]
+postgres = ["tokio-postgres"]
 
 [workspace]
 members = [".", "./macros", "./fuzzer"]

--- a/tests/decimal_tests.rs
+++ b/tests/decimal_tests.rs
@@ -3,6 +3,7 @@
 use float_cmp::*;
 use num::{ToPrimitive, Zero};
 use rust_decimal::{Decimal, RoundingStrategy};
+use bytes::BytesMut;
 
 use std::{
     cmp::{Ordering, Ordering::*},
@@ -1362,9 +1363,9 @@ fn to_from_sql() {
 
     for test in tests {
         let input = Decimal::from_str(test).unwrap();
-        let mut vec = Vec::<u8>::new();
-        input.to_sql(&t, &mut vec).unwrap();
-        let output = Decimal::from_sql(&t, &vec).unwrap();
+        let mut bytes = BytesMut::new();
+        input.to_sql(&t, &mut bytes).unwrap();
+        let output = Decimal::from_sql(&t, &bytes).unwrap();
 
         assert_eq!(input, output);
     }


### PR DESCRIPTION
Hey,

Async/await is coming and new tokio-postgres. It was a bit trickier this time due to the switch to `bytes`.